### PR TITLE
Also use lowercased strings for finding the color in the config.

### DIFF
--- a/app.py
+++ b/app.py
@@ -52,7 +52,7 @@ class p4bot:
 
     def get_color(self, change):
         for filter in self.config["filters"]:
-            if change.text.find(filter["tag"]) != -1:
+            if change.text.lower().find(filter["tag"].lower()) != -1:
                     return int(filter['color'],16)
         return 0xc8702a
 


### PR DESCRIPTION
Also use lowercased strings for finding the color in the config.

Fixes the issue below where the color isn't found for fix/fixed and it is for Fix/Fixed because Fix/Fixed is used in the config.

![image](https://user-images.githubusercontent.com/6069593/57854823-74130680-77e9-11e9-8106-4689f32e75a5.png)
