### PR TITLE
Separate webhook for review and commit messages.

### DIFF
--- a/commit.py
+++ b/commit.py
@@ -9,7 +9,7 @@ class p4bot_commit:
         self.storage = p4.Storage()
         try:
             self.config = utils.create_config("config.json")
-            self.discord = discord.Discord(self.config)
+            self.discord = discord.Discord(self.config, "commit_webhook")
             self.perforce = p4.init(self.config)
         except AssertionError as error:
                 assert False, error

--- a/config.json
+++ b/config.json
@@ -9,7 +9,7 @@
         "decode": "ISO-8859-1",
         "swarm": ""
     },
-    "pull_interval": 30.0,
+    "pull_interval": 30,
     "filters": [
         {
             "tag": "ADD",
@@ -18,12 +18,29 @@
     ],
     "use_filter": true,
     "discord": {
-        "webhook_url": "",
-        "name": "Swarm Review",
-        "users":[{"swarm":"User1","discord":"123123123"},{"swarm":"User2","discord":"12233445"}]
+        "webhooks": {
+            "commit_webhook": {
+                "url": "",
+                "name": "Perforce Commit"
+            },
+            "review_webhook": {
+                "url": "",
+                "name": "Swarm Review"
+            }
+        },
+        "users": [
+            {
+                "swarm": "User1",
+                "discord": "123123123"
+            },
+            {
+                "swarm": "User2",
+                "discord": "12233445"
+            }
+        ]
     },
-    "server":{
-        "host":"",
-        "port":8080
+    "server": {
+        "host": "",
+        "port": 8080
     }
 }

--- a/discord.py
+++ b/discord.py
@@ -13,10 +13,10 @@ class Message:
     url = None
 
 class Discord:
-    def __init__(self,config):
+    def __init__(self,config,webhook):
         self.data = discord_data()
-        self.data.url = config['discord']['webhook_url']
-        self.data.name = config['discord']['name']
+        self.data.url = config['discord']['webhooks'][webhook]['url']
+        self.data.name = config['discord']['webhooks'][webhook]['name']
         self.webhook = DiscordWebhooks(self.data.url)
 
     def send(self,message):

--- a/review.py
+++ b/review.py
@@ -16,7 +16,7 @@ class p4bot_review:
         self.exit_flag = True
         try:
             self.config = utils.create_config("config.json")
-            self.discord = discord.Discord(self.config)
+            self.discord = discord.Discord(self.config, "review_webhook")
             self.perforce = p4.init(self.config)
         except AssertionError as error:
             mutex.acquire()


### PR DESCRIPTION
Separate the webhooks for commits and reviews in the config to allow sending these messages in different channels.